### PR TITLE
opc: accept directories in lint

### DIFF
--- a/labs/opc-company/scripts/opc.py
+++ b/labs/opc-company/scripts/opc.py
@@ -18,15 +18,28 @@ def lint_task(task):
     return errors
 
 def cmd_lint(args):
-    errors=[]
-    for p in args.files:
-        obj=read_json(p)
+    errors=[]; files=[]
+    for raw in args.files:
+        path=Path(raw)
+        if not path.exists():
+            errors.append(f"{raw}:not_found")
+            continue
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.json")))
+        else:
+            files.append(path)
+    for path in files:
+        try:
+            obj=read_json(path)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{path}:unreadable_json:{exc.__class__.__name__}")
+            continue
         if isinstance(obj, dict) and "status" in obj and "id" in obj:
-            errors += [f"{p}:{e}" for e in lint_task(obj)]
+            errors += [f"{path}:{e}" for e in lint_task(obj)]
     if errors:
         for e in errors: print("OPC_LINT_ERROR", e)
         return 1
-    print(f"OPC_LINT_OK files={len(args.files)}")
+    print(f"OPC_LINT_OK files={len(files)}")
     return 0
 
 def cmd_status(args):

--- a/labs/opc-company/tests/run.py
+++ b/labs/opc-company/tests/run.py
@@ -17,4 +17,5 @@ out=run(["continuation","--before",str(ROOT/"fixtures/continuation/before.json")
 out=run(["continuation","--before",str(ROOT/"fixtures/continuation/before.json"),"--after",str(ROOT/"fixtures/continuation/after.bad-scope-drift.json")],1); assert "scope_drift_without_handoff" in out
 out=run(["continuation","--before",str(ROOT/"fixtures/continuation/before.json"),"--after",str(ROOT/"fixtures/continuation/after.good-leaf-continue.json")],0); assert "OPC_CONTINUATION_PASS" in out
 task_files=[str(p) for p in (ROOT/"examples/synthetic-company/tasks").glob("*.json")]; out=run(["lint",*task_files],0); assert "OPC_LINT_OK" in out
+out=run(["lint",str(ROOT/"examples/synthetic-company")],0); assert "OPC_LINT_OK" in out
 print("OPC_TEST_OK")


### PR DESCRIPTION
Incident-driven UX fix from an external-agent clean-checkout run. The lint command previously raised IsADirectoryError when an agent naturally passed the synthetic company directory. This patch expands directory inputs to JSON files, returns controlled OPC_LINT_ERROR for bad paths or JSON instead of tracebacks, and adds a regression test. Local validation passed: OPC_TEST_OK, QuietHarness VERIFY_OK, OPC_LINT_OK files=5, and git diff check.