### PR TITLE
docs: expose OPC adoption proofs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -22,6 +22,8 @@ QuietHarness is for people maintaining real projects with any supported AI codin
 
 QuietHarness does not include a task database, background automation, or a team orchestration platform. The larger Leo System later in this README is an optional reference, not a prerequisite.
 
+If you are exploring how multiple long-lived owners/workers can share canonical state, use semantic handoffs, reject false completion, and continue the same task after worker failover, see the experimental [OPC Company Layer](labs/opc-company/README.en.md). It is a governance lab in this same repository, not a QuietHarness installation requirement.
+
 ## Try it inside one isolated project
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ QuietHarness 不会给每个请求套一层仪式，也不是要求你复制我�
 
 如果你需要完整任务数据库、后台自动化或团队编排平台，QuietHarness 本身并不提供这些能力；后文的 Leo System 只是可选参考。
 
+如果你关心多个长期 Owner / Worker 如何共享 canonical state、做 semantic handoff、拒绝假完成并在换 worker 后继续同一任务，可以看实验性的 [OPC Company Layer](labs/opc-company/README.md)。它是同一仓库里的治理实验层，不是 QuietHarness 的安装前提。
+
 ## 先在一个隔离项目试用
 
 ```bash

--- a/labs/opc-company/README.en.md
+++ b/labs/opc-company/README.en.md
@@ -61,6 +61,16 @@ python3 scripts/opc.py continuation   --before fixtures/continuation/before.json
 # exact output:
 # OPC_CONTINUATION_PASS task=synthetic-content-task scope=opc-merge-milestone work_continuing=true
 
+# 8) A handoff without semantic downstream ACK is not completion
+python3 scripts/opc.py verify   --task fixtures/missing-ack/task.json   --receipt fixtures/missing-ack/receipt.json
+# exit 1
+# exact token: OPC_VERIFY_REJECT missing_semantic_ack
+
+# 9) lint accepts a company directory and checks its JSON files
+python3 scripts/opc.py lint examples/synthetic-company
+# exit 0
+# exact output: OPC_LINT_OK files=5
+
 # Optional full regression suite
 python3 tests/run.py
 # exit 0; exact token: OPC_TEST_OK

--- a/labs/opc-company/README.md
+++ b/labs/opc-company/README.md
@@ -61,6 +61,16 @@ python3 scripts/opc.py continuation   --before fixtures/continuation/before.json
 # 精确输出：
 # OPC_CONTINUATION_PASS task=synthetic-content-task scope=opc-merge-milestone work_continuing=true
 
+# 8) handoff 已发出但缺 semantic downstream ACK：不能算完成
+python3 scripts/opc.py verify   --task fixtures/missing-ack/task.json   --receipt fixtures/missing-ack/receipt.json
+# exit 1
+# 精确 token：OPC_VERIFY_REJECT missing_semantic_ack
+
+# 9) lint 接受 company 目录输入，并递归检查其中 JSON
+python3 scripts/opc.py lint examples/synthetic-company
+# exit 0
+# 精确输出：OPC_LINT_OK files=5
+
 # 可选：完整回归测试
 python3 tests/run.py
 # exit 0；精确 token：OPC_TEST_OK


### PR DESCRIPTION
Incident-driven documentation update after external-agent validation. It makes semantic ACK rejection and directory lint directly reproducible in OPC First Success, and adds a small root README discovery link so an external agent can find the experimental OPC Company Layer without being given a deep link. The link explicitly remains optional and does not change QuietHarness installation. Local OPC and QuietHarness verification passed, and a clean external-agent run discovered OPC from the root README and reproduced status first success without private context.